### PR TITLE
CurrencyExchangeRater was CanCurrencyExchangeRate

### DIFF
--- a/src/main/java/walkingkooka/currency/CurrencyContext.java
+++ b/src/main/java/walkingkooka/currency/CurrencyContext.java
@@ -28,10 +28,10 @@ import java.util.Set;
  * A {@link Context} with some {@link Currency} operations.
  */
 public interface CurrencyContext extends Context,
-    CanCurrencyExchangeRate,
     CanCurrencyForCurrencyCode,
     CanCurrencyForLocale,
     CanLocalesForCurrencyCode,
+    CurrencyExchangeRater,
     HasCurrency {
 
     /**

--- a/src/main/java/walkingkooka/currency/CurrencyContextTesting.java
+++ b/src/main/java/walkingkooka/currency/CurrencyContextTesting.java
@@ -27,9 +27,9 @@ import java.util.Optional;
 import java.util.Set;
 
 public interface CurrencyContextTesting extends CanCurrencyForCurrencyCodeTesting,
-    CanCurrencyExchangeRateTesting,
     CanCurrencyForLocaleTesting,
     CanLocalesForCurrencyCodeTesting,
+    CurrencyExchangeRaterTesting,
     HasCurrencyTesting,
     TreePrintableTesting {
 

--- a/src/main/java/walkingkooka/currency/CurrencyContextTesting2.java
+++ b/src/main/java/walkingkooka/currency/CurrencyContextTesting2.java
@@ -25,11 +25,11 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public interface CurrencyContextTesting2<C extends CurrencyContext> extends CurrencyContextTesting,
-    CanCurrencyExchangeRateTesting2<C>,
     CanCurrencyForCurrencyCodeTesting2<C>,
     CanCurrencyForLocaleTesting2<C>,
     CanLocalesForCurrencyCodeTesting2<C>,
-    ContextTesting<C> {
+    ContextTesting<C>,
+    CurrencyExchangeRaterTesting2<C> {
 
     // setCurrency......................................................................................................
 
@@ -136,7 +136,7 @@ public interface CurrencyContextTesting2<C extends CurrencyContext> extends Curr
     }
 
     @Override
-    default C createCanCurrencyExchangeRate() {
+    default C createCurrencyExchangeRater() {
         return this.createContext();
     }
 

--- a/src/main/java/walkingkooka/currency/CurrencyContexts.java
+++ b/src/main/java/walkingkooka/currency/CurrencyContexts.java
@@ -49,7 +49,7 @@ public final class CurrencyContexts implements PublicStaticHelper {
      * {@see JreCurrencyContext}
      */
     public static CurrencyContext jre(final Currency currency,
-                                      final CanCurrencyExchangeRate exchangeRates,
+                                      final CurrencyExchangeRater exchangeRates,
                                       final LocaleContext localeContext) {
         return JreCurrencyContext.with(
             currency,

--- a/src/main/java/walkingkooka/currency/CurrencyExchangeRater.java
+++ b/src/main/java/walkingkooka/currency/CurrencyExchangeRater.java
@@ -20,7 +20,7 @@ package walkingkooka.currency;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public interface CanCurrencyExchangeRate {
+public interface CurrencyExchangeRater {
 
     Number exchangeRate(final CurrencyCode from,
                         final CurrencyCode to,

--- a/src/main/java/walkingkooka/currency/CurrencyExchangeRaterTesting.java
+++ b/src/main/java/walkingkooka/currency/CurrencyExchangeRaterTesting.java
@@ -22,9 +22,9 @@ import walkingkooka.text.printer.TreePrintableTesting;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public interface CanCurrencyExchangeRateTesting extends TreePrintableTesting {
+public interface CurrencyExchangeRaterTesting extends TreePrintableTesting {
 
-    default void exchangeRateAndCheck(final CanCurrencyExchangeRate can,
+    default void exchangeRateAndCheck(final CurrencyExchangeRater can,
                                       final CurrencyCode from,
                                       final CurrencyCode to,
                                       final Number expected) {
@@ -37,7 +37,7 @@ public interface CanCurrencyExchangeRateTesting extends TreePrintableTesting {
         );
     }
 
-    default void exchangeRateAndCheck(final CanCurrencyExchangeRate can,
+    default void exchangeRateAndCheck(final CurrencyExchangeRater can,
                                       final CurrencyCode from,
                                       final CurrencyCode to,
                                       final LocalDateTime dateTime,
@@ -51,7 +51,7 @@ public interface CanCurrencyExchangeRateTesting extends TreePrintableTesting {
         );
     }
 
-    default void exchangeRateAndCheck(final CanCurrencyExchangeRate can,
+    default void exchangeRateAndCheck(final CurrencyExchangeRater can,
                                       final CurrencyCode from,
                                       final CurrencyCode to,
                                       final Optional<LocalDateTime> dateTime,

--- a/src/main/java/walkingkooka/currency/CurrencyExchangeRaterTesting2.java
+++ b/src/main/java/walkingkooka/currency/CurrencyExchangeRaterTesting2.java
@@ -23,15 +23,15 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public interface CanCurrencyExchangeRateTesting2<C extends CanCurrencyExchangeRate> extends CanCurrencyExchangeRateTesting {
+public interface CurrencyExchangeRaterTesting2<C extends CurrencyExchangeRater> extends CurrencyExchangeRaterTesting {
 
-    // currencyExchangeRate.............................................................................................
+    // exchangeRate.....................................................................................................
 
     @Test
     default void testExchangeRateWithNullFromFails() {
         assertThrows(
             NullPointerException.class,
-            () -> this.createCanCurrencyExchangeRate()
+            () -> this.createCurrencyExchangeRater()
                 .exchangeRate(
                     null,
                     CurrencyCode.parse("NZD"),
@@ -44,7 +44,7 @@ public interface CanCurrencyExchangeRateTesting2<C extends CanCurrencyExchangeRa
     default void testExchangeRateWithNullToFails() {
         assertThrows(
             NullPointerException.class,
-            () -> this.createCanCurrencyExchangeRate()
+            () -> this.createCurrencyExchangeRater()
                 .exchangeRate(
                     CurrencyCode.parse("AUD"),
                     null,
@@ -57,7 +57,7 @@ public interface CanCurrencyExchangeRateTesting2<C extends CanCurrencyExchangeRa
     default void testExchangeRateWithNullDateTimeFails() {
         assertThrows(
             NullPointerException.class,
-            () -> this.createCanCurrencyExchangeRate()
+            () -> this.createCurrencyExchangeRater()
                 .exchangeRate(
                     CurrencyCode.parse("AUD"),
                     CurrencyCode.parse("NZD"),
@@ -66,5 +66,5 @@ public interface CanCurrencyExchangeRateTesting2<C extends CanCurrencyExchangeRa
         );
     }
 
-    C createCanCurrencyExchangeRate();
+    C createCurrencyExchangeRater();
 }

--- a/src/main/java/walkingkooka/currency/ExchangeRate.java
+++ b/src/main/java/walkingkooka/currency/ExchangeRate.java
@@ -33,7 +33,7 @@ import java.util.function.BiFunction;
  * AUD-NZD=1.1
  * </pre>
  */
-public final class ExchangeRate implements CanCurrencyExchangeRate,
+public final class ExchangeRate implements CurrencyExchangeRater,
     HasProperties {
 
     public static ExchangeRate fromProperties(final Properties properties,
@@ -60,7 +60,7 @@ public final class ExchangeRate implements CanCurrencyExchangeRate,
         return this.properties;
     }
 
-    // CanCurrencyExchangeRate..........................................................................................
+    // CurrencyExchangeRater..........................................................................................
 
     @Override
     public Number exchangeRate(final CurrencyCode from,

--- a/src/main/java/walkingkooka/currency/FakeCurrencyExchangeRater.java
+++ b/src/main/java/walkingkooka/currency/FakeCurrencyExchangeRater.java
@@ -20,9 +20,9 @@ package walkingkooka.currency;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public class FakeCanCurrencyExchangeRate implements CanCurrencyExchangeRate {
+public class FakeCurrencyExchangeRater implements CurrencyExchangeRater {
 
-    public FakeCanCurrencyExchangeRate() {
+    public FakeCurrencyExchangeRater() {
         super();
     }
 

--- a/src/main/java/walkingkooka/currency/JreCurrencyContext.java
+++ b/src/main/java/walkingkooka/currency/JreCurrencyContext.java
@@ -36,7 +36,7 @@ import java.util.SortedSet;
 final class JreCurrencyContext implements CurrencyContext {
 
     static JreCurrencyContext with(final Currency currency,
-                                   final CanCurrencyExchangeRate exchangeRates,
+                                   final CurrencyExchangeRater exchangeRates,
                                    final LocaleContext localeContext) {
         return new JreCurrencyContext(
             Objects.requireNonNull(currency, "currency"),
@@ -46,7 +46,7 @@ final class JreCurrencyContext implements CurrencyContext {
     }
 
     private JreCurrencyContext(final Currency currency,
-                               final CanCurrencyExchangeRate exchangeRates,
+                               final CurrencyExchangeRater exchangeRates,
                                final LocaleContext localeContext) {
         this.currency = currency;
         this.exchangeRates = exchangeRates;
@@ -220,7 +220,7 @@ final class JreCurrencyContext implements CurrencyContext {
         );
     }
 
-    private final CanCurrencyExchangeRate exchangeRates;
+    private final CurrencyExchangeRater exchangeRates;
 
     @Override
     public String toString() {

--- a/src/test/java/walkingkooka/currency/ExchangeRateTest.java
+++ b/src/test/java/walkingkooka/currency/ExchangeRateTest.java
@@ -30,7 +30,7 @@ import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public final class ExchangeRateTest implements CanCurrencyExchangeRateTesting2<ExchangeRate>,
+public final class ExchangeRateTest implements CurrencyExchangeRaterTesting2<ExchangeRate>,
     HasPropertiesTesting,
     HashCodeEqualsDefinedTesting2<ExchangeRate>,
     ToStringTesting<ExchangeRate>,
@@ -78,7 +78,7 @@ public final class ExchangeRateTest implements CanCurrencyExchangeRateTesting2<E
     @Test
     public void testProperties() {
         this.propertiesAndCheck(
-            this.createCanCurrencyExchangeRate(),
+            this.createCurrencyExchangeRater(),
             PROPERTIES
         );
     }
@@ -88,7 +88,7 @@ public final class ExchangeRateTest implements CanCurrencyExchangeRateTesting2<E
     @Test
     public void testExchangeRate() {
         this.exchangeRateAndCheck(
-            this.createCanCurrencyExchangeRate(),
+            this.createCurrencyExchangeRater(),
             CurrencyCode.parse("AUD"),
             CurrencyCode.parse("NZD"),
             new BigDecimal("1.1")
@@ -98,7 +98,7 @@ public final class ExchangeRateTest implements CanCurrencyExchangeRateTesting2<E
     @Test
     public void testExchangeRateInverted() {
         this.exchangeRateAndCheck(
-            this.createCanCurrencyExchangeRate(),
+            this.createCurrencyExchangeRater(),
             CurrencyCode.parse("NZD"),
             CurrencyCode.parse("AUD"),
             new BigDecimal("0.91")
@@ -106,7 +106,7 @@ public final class ExchangeRateTest implements CanCurrencyExchangeRateTesting2<E
     }
 
     @Override
-    public ExchangeRate createCanCurrencyExchangeRate() {
+    public ExchangeRate createCurrencyExchangeRater() {
         return ExchangeRate.fromProperties(
             PROPERTIES,
             NUMBER_PARSER
@@ -139,7 +139,7 @@ public final class ExchangeRateTest implements CanCurrencyExchangeRateTesting2<E
 
     @Override
     public ExchangeRate createObject() {
-        return this.createCanCurrencyExchangeRate();
+        return this.createCurrencyExchangeRater();
     }
 
     // toString.........................................................................................................
@@ -147,7 +147,7 @@ public final class ExchangeRateTest implements CanCurrencyExchangeRateTesting2<E
     @Test
     public void testToString() {
         this.toStringAndCheck(
-            this.createCanCurrencyExchangeRate(),
+            this.createCurrencyExchangeRater(),
             PROPERTIES.toString()
         );
     }

--- a/src/test/java/walkingkooka/currency/JreCurrencyContextTest.java
+++ b/src/test/java/walkingkooka/currency/JreCurrencyContextTest.java
@@ -33,7 +33,7 @@ public final class JreCurrencyContextTest implements CurrencyContextTesting2<Jre
 
     private final static Currency CURRENCY = Currency.getInstance("AUD");
 
-    private final static CanCurrencyExchangeRate EXCHANGE = (CurrencyCode from, CurrencyCode to, Optional<LocalDateTime> dateTime) -> {
+    private final static CurrencyExchangeRater EXCHANGE = (CurrencyCode from, CurrencyCode to, Optional<LocalDateTime> dateTime) -> {
         Objects.requireNonNull(from, "from");
         Objects.requireNonNull(to, "to");
         Objects.requireNonNull(dateTime, "dateTime");


### PR DESCRIPTION
- First step to introducing selectors and plugin provider

- Closes https://github.com/mP1/walkingkooka-currency/issues/111
- CurrencyExchanger extends CanCurrencyExchangeRate